### PR TITLE
update opam package definition for Coq 8.9 and with other metadata

### DIFF
--- a/opam
+++ b/opam
@@ -6,19 +6,21 @@ maintainer: "FCSL <fcsl@software.imdea.org>"
 homepage: "http://software.imdea.org/fcsl/"
 bug-reports: "https://github.com/imdea-software/fcsl-pcm/issues"
 dev-repo: "https://github.com/imdea-software/fcsl-pcm.git"
-license: "Apache 2.0"
+license: "Apache-2.0"
 
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/fcsl'" ]
 depends: [
-  "coq" {(>= "8.7" & < "8.9~") | (= "dev")}
+  "coq" {(>= "8.7" & < "8.10~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.6.2" & < "1.8~") | (= "dev")}
 ]
 
 tags: [
   "keyword:separation logic"
   "keyword:partial commutative monoid"
+  "category:Computer Science/Data Types and Data Structures"
+  "logpath:fcsl"
 ]
 authors: [
   "Aleksandar Nanevski"


### PR DESCRIPTION
The repo works fine for me with Coq 8.9.0, so updated `opam` file to reflect this. Also using canonical SPDX string for license, and added some more OPAM metadata.

Any chance for a new version soon that can live in the `released` Coq OPAM repo?