### PR TITLE
[coq] Be explicit about the dependency on Setoid rules.

### DIFF
--- a/finmap/finmap.v
+++ b/finmap/finmap.v
@@ -19,6 +19,8 @@ limitations under the License.
 From Coq Require Import ssreflect ssrbool ssrfun.
 From mathcomp Require Import ssrnat eqtype seq path.
 From fcsl Require Import ordtype.
+From Coq Require Setoid.
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.

--- a/pcm/mutex.v
+++ b/pcm/mutex.v
@@ -22,6 +22,8 @@ limitations under the License.
 From Coq Require Import ssreflect ssrbool ssrfun.
 From mathcomp Require Import ssrnat eqtype.
 From fcsl Require Import prelude pcm.
+From Coq Require Setoid.
+
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.


### PR DESCRIPTION
A couple of files depend on `Setoid` rewriting implicitly.

As of today, `Setoid` rules are placed in scope by `ssrnat`, but IMO
you should not rely on this behavior as `ssrnat` may stop requiring
`Setoid` in the future.

The patch is fully backwards compatible.