### PR TITLE
Fix w.r.t. math-comp/math-comp#601 which renames `eq_sorted(_irr)` to `sorted_eq(_irr)`

### DIFF
--- a/pcm/unionmap.v
+++ b/pcm/unionmap.v
@@ -3570,7 +3570,7 @@ Implicit Type p q : pred K.
 
 Lemma dom_umfiltk_filter p f : dom (um_filterk p f) = filter p (dom f).
 Proof.
-apply: (eq_sorted_irr (leT:=ord)).
+apply: (@eq_sorted_irr _ ord).
 - by apply: trans.
 - by apply: irr.
 - by apply: sorted_dom.


### PR DESCRIPTION
We are about to rename `eq_sorted` lemmas to `sorted_eq` to address a naming inconsistency in MathComp (see https://github.com/math-comp/math-comp/pull/601#issuecomment-705046342). Unfortunately, this deprecation breaks fcsl-pcm and lemma-overloading because the deprecation facility of MathComp does not support the `(ident := term)` syntax for explicit applications. As a workaround, I propose to use `@` syntax instead.