### PR TITLE
Don't rely on ssreflect setoid rewrite bug (coq/coq#13882)

### DIFF
--- a/pcm/unionmap.v
+++ b/pcm/unionmap.v
@@ -2938,7 +2938,7 @@ split=>[H|[w1][C' V1 H E]].
 - move: (dom_valid (In_dom H)); rewrite omapPtUn W in H *.
   case E: (a (x, w)) H=>[z|] H W1; last first.
   - by case/IH: H=>w1 []; exists w1; split=>//; apply/InR.
-  rewrite InPtUnE // in H *.
+  revert H;rewrite InPtUnE //.
   case; first by case=>->->; exists w; rewrite (validPtUn_cond W1).
   by case/IH=>w1 []; exists w1; split=>//; apply/InR.
 rewrite omapPtUn W in V1 *; move/(InPtUnE _ W): H=>H.


### PR DESCRIPTION
Before the mentioned Coq PR, "rewrite foo in H *" with ssreflect
rewrite and a setoid equality would leave the goal with H reverted.

Instead we manually revert H and don't use "in".

This should be backwards compatible and so may be merged now.