### PR TITLE
Fix w.r.t. the removal of `eq_sorted_irr` in MathComp

### DIFF
--- a/core/ordtype.v
+++ b/core/ordtype.v
@@ -82,6 +82,12 @@ Definition oleq (T : ordType) (t1 t2 : T) := ord t1 t2 || (t1 == t2).
 
 Prenex Implicits ord oleq.
 
+(* Remove when dropping the compatibility with MathComp 1.11.0: *)
+Local Lemma irr_sorted_eq (T : eqType) (leT : rel T) :
+  transitive leT -> irreflexive leT ->
+  forall s1 s2 : seq T, sorted leT s1 -> sorted leT s2 -> s1 =i s2 -> s1 = s2.
+Proof. by [exact: irr_sorted_eq | exact: eq_sorted_irr]. Qed.
+
 Section Lemmas.
 Variable T : ordType.
 Implicit Types x y : T.
@@ -131,9 +137,9 @@ Lemma path_filter (r : rel T) (tr : transitive r) s (p : pred T) x :
         path r x s -> path r x (filter p s).
 Proof. exact: (subseq_order_path tr (filter_subseq p s)). Qed.
 
-Lemma eq_sorted_ord (s1 s2 : seq T) :
+Lemma ord_sorted_eq (s1 s2 : seq T) :
         sorted ord s1 -> sorted ord s2 -> s1 =i s2 -> s1 = s2.
-Proof. by apply: eq_sorted_irr; [apply: trans | apply: irr]. Qed.
+Proof. exact/irr_sorted_eq/irr/trans. Qed.
 
 End Lemmas.
 
@@ -442,7 +448,7 @@ Lemma sorted_subset_subseq (A : eqType) (s1 s2 : seq A) leT :
 Proof.
 move=>R T S1 S2 H.
 suff -> : s1 = filter (fun x => x \in s1) s2 by apply: filter_subseq.
-apply: eq_sorted_irr S1 _ _=>//; first by rewrite sorted_filter.
+apply: irr_sorted_eq S1 _ _=>//; first by rewrite sorted_filter.
 by move=>k; rewrite mem_filter; case S : (_ \in _)=>//; rewrite (H _ S).
 Qed.
 
@@ -566,3 +572,6 @@ rewrite (path_min_sorted P); apply: IH=>[|a b Xa Xb N]; first by case/andP: U.
 apply: H; rewrite ?(inE,Xa,Xb,orbT) //.
 by case: eqP U=>[->|]; case: eqP=>[->|]; rewrite ?(Xa,Xb).
 Qed.
+
+#[deprecated(note="Use ord_sorted_eq instead.")]
+Notation eq_sorted_ord := ord_sorted_eq (only parsing).

--- a/pcm/unionmap.v
+++ b/pcm/unionmap.v
@@ -844,11 +844,7 @@ Prenex Implicits find_some find_none.
 Lemma domE K C V1 V2 (U1 : @union_map_class K C V1) (U2 : @union_map_class K C V2)
            (f1 : U1) (f2 : U2) :
         dom f1 =i dom f2 <-> dom f1 = dom f2.
-Proof.
-split=>[|->] //.
-apply: (@eq_sorted_irr _ ord);
-by [apply: trans|apply: irr|apply: sorted_dom|apply: sorted_dom].
-Qed.
+Proof. by split=>[|->] //; apply/ord_sorted_eq/sorted_dom/sorted_dom. Qed.
 
 (*********)
 (* valid *)
@@ -1792,7 +1788,7 @@ Lemma domPtUnK k v f :
         all (ord k) (dom f) ->
         dom (pts k v \+ f) = k :: dom f.
 Proof.
-move=>W H; apply: (@eq_sorted_irr K ord) =>//=.
+move=>W H; apply: ord_sorted_eq => //=.
 - by rewrite path_min_sorted //; apply: sorted_dom.
 by move=>x; rewrite domPtUn !inE W eq_sym.
 Qed.
@@ -1802,7 +1798,7 @@ Lemma domUnPtK k v f :
         all (ord^~k) (dom f) ->
         dom (f \+ pts k v) = rcons (dom f) k.
 Proof.
-move=>W H; apply: (@eq_sorted_irr K ord)=>//=.
+move=>W H; apply: ord_sorted_eq => //=.
 - rewrite -(rev_sorted (fun x=>ord^~x)) rev_rcons /=.
   by rewrite path_min_sorted ?rev_sorted // all_rev.
 by move=>x; rewrite domUnPt inE W mem_rcons inE eq_sym.
@@ -3359,7 +3355,7 @@ Lemma dom_umfiltE p f :
         filter (fun k => if find k f is Some v then p (k, v) else false)
                (dom f).
 Proof.
-apply: (@eq_sorted_irr _ ord); [apply: trans|apply: irr|apply: sorted_dom| | ].
+apply: ord_sorted_eq => //=.
 - by apply: sorted_filter; [apply: trans | apply: sorted_dom].
 move=>k; rewrite mem_filter; apply/idP/idP.
 - by case/dom_umfilt=>w [H1 H2]; move/In_find: H2 (H2) H1=>-> /In_dom ->->.
@@ -3570,10 +3566,7 @@ Implicit Type p q : pred K.
 
 Lemma dom_umfiltk_filter p f : dom (um_filterk p f) = filter p (dom f).
 Proof.
-apply: (@eq_sorted_irr _ ord).
-- by apply: trans.
-- by apply: irr.
-- by apply: sorted_dom.
+apply: ord_sorted_eq => //=.
 - by apply: sorted_filter; [apply: trans | apply: sorted_dom].
 move=>k; rewrite mem_filter; apply/idP/idP.
 - by case/dom_umfilt=>v [/= -> /In_dom].


### PR DESCRIPTION
- Context: `eq_sorted_irr` has been deprecated and renamed to `irr_sorted_eq` in MathComp 1.12.0 (see math-comp/math-comp#646), and this deprecation alias will be removed in MathComp 1.13.0 (see math-comp/math-comp#727).
- This change adds a local alias for `irr_sorted_eq` (which serves as a compatibility layer for MathComp 1.11.0) in `ordtype.v`, deprecates and renames `eq_sorted_ord` to `ord_sorted_eq` so that it is compatible with the current naming convention of MathComp, and replaces the most occurrences of `eq_sorted_irr` with `ord_sorted_eq`.