### PR TITLE
Preparing fcsl-pcm release v.2.1.0

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,7 +19,7 @@ jobs:
         image:
           - 'mathcomp/mathcomp:2.2.0-coq-8.19'
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
-          - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:latest-coq-dev'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,7 +19,7 @@ jobs:
         image:
           - 'mathcomp/mathcomp:2.2.0-coq-8.19'
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
-          - 'mathcomp/mathcomp-dev:oq-dev'
+          - 'mathcomp/mathcomp-dev:coq-dev'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,7 +19,7 @@ jobs:
         image:
           - 'mathcomp/mathcomp:2.2.0-coq-8.19'
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
-          - 'mathcomp/mathcomp:latest-coq-dev'
+          - 'mathcomp/mathcomp-dev:oq-dev'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,7 +19,7 @@ jobs:
         image:
           - 'mathcomp/mathcomp:2.2.0-coq-8.19'
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
-          - 'mathcomp/mathcomp:latest-coq-dev'
+          - 'mathcomp/mathcomp-dev:coq-dev'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library relies on propositional and functional extentionality axioms.
 - License: [Apache-2.0](LICENSE)
 - Compatible Coq versions: Coq 8.19 to 8.20
 - Additional dependencies:
-  - [MathComp ssreflect 2.2](https://math-comp.github.io)
+  - [MathComp ssreflect 2.2 or later](https://math-comp.github.io)
   - [Hierarchy Builder 1.7.0 or later](https://github.com/math-comp/hierarchy-builder)
   - [MathComp algebra](https://math-comp.github.io)
 - Coq namespace: `pcm`

--- a/_CoqProject
+++ b/_CoqProject
@@ -12,6 +12,7 @@ core/axioms.v
 core/prelude.v
 core/pred.v
 core/auto.v
+core/autouniq.v
 core/seqext.v
 core/slice.v
 core/uslice.v

--- a/coq-fcsl-pcm.opam
+++ b/coq-fcsl-pcm.opam
@@ -27,7 +27,7 @@ install: [make "install"]
 depends: [
   "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.2.0" & < "2.4~") | (= "dev") }
-  "coq-hierarchy-builder" {>= "1.7.0" & < "1.9~"} | (= "dev") }
+  "coq-hierarchy-builder" { (>= "1.7.0" & < "1.9~") | (= "dev") }
   "coq-mathcomp-algebra" 
 ]
 

--- a/coq-fcsl-pcm.opam
+++ b/coq-fcsl-pcm.opam
@@ -27,7 +27,7 @@ install: [make "install"]
 depends: [
   "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.2.0" & < "2.4~") | (= "dev") }
-  "coq-hierarchy-builder" {>= "1.7.0"}
+  "coq-hierarchy-builder" {>= "1.7.0" & < "1.8~"} | (= "dev") }
   "coq-mathcomp-algebra" 
 ]
 

--- a/coq-fcsl-pcm.opam
+++ b/coq-fcsl-pcm.opam
@@ -27,7 +27,7 @@ install: [make "install"]
 depends: [
   "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.2.0" & < "2.4~") | (= "dev") }
-  "coq-hierarchy-builder" {>= "1.7.0" & < "1.8~"} | (= "dev") }
+  "coq-hierarchy-builder" {>= "1.7.0" & < "1.9~"} | (= "dev") }
   "coq-mathcomp-algebra" 
 ]
 

--- a/core/autouniq.v
+++ b/core/autouniq.v
@@ -65,7 +65,7 @@ Inductive term := Pts of nat | Var of nat.
 Definition eq_term t1 t2 : bool :=
   match t1, t2 with 
   | Pts n1, Pts n2 => n1 == n2
-  | Var v1, Var v2 => v1 == v2
+  | Var x1, Var x2 => x1 == x2
   | _, _ => false
   end.
 Lemma eq_termP : Equality.axiom eq_term.

--- a/core/autouniq.v
+++ b/core/autouniq.v
@@ -1,0 +1,618 @@
+(*
+Copyright 2024 IMDEA Software Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+From HB Require Import structures.
+From Coq Require Import ssreflect ssrbool ssrfun.
+From mathcomp Require Import ssrnat seq eqtype.
+From pcm Require Import options prelude auto.
+
+(**********************************************************)
+(**********************************************************)
+(* Canonical structure lemmas for automating three tasks  *)
+(* given hypothesis uniq s, of uniqueness of elements of  *)
+(* sequence s.                                            *)
+(*                                                        *)
+(* 1. Automate inferring uniq s', when s' contains subset *)
+(* of elements of s                                       *)
+(*                                                        *)
+(* 2. Automate inferring facts of the form x != y         *)
+(* when x and y are both in s                             *)
+(*                                                        *)
+(* 3. Automate inferring facts of the form x \notin s'    *)
+(* when x::s' contains subset of elements of s            *)
+(**********************************************************)
+(**********************************************************)
+
+
+Section UniqReflectionContexts.
+Variable A : eqType.
+
+Structure ctx := Context {keyx : seq A; varx : seq (seq A)}.
+Definition empx := Context [::] [::].
+
+(* sub-context *)
+Definition sub_ctx (i j : ctx) :=
+  Prefix (keyx i) (keyx j) /\ Prefix (varx i) (varx j).
+
+Lemma sc_refl i : sub_ctx i i.
+Proof. by []. Qed.
+
+Lemma sc_trans i j k : 
+        sub_ctx i j -> 
+        sub_ctx j k -> 
+        sub_ctx i k.
+Proof. 
+by case=>K1 V1 [K2 V2]; split; [move: K2|move: V2]; apply: Prefix_trans. 
+Qed.
+
+End UniqReflectionContexts.
+
+Section UniqReflection.
+Variable A : eqType.
+Implicit Type i : ctx A.
+Inductive term := Pts of nat | Var of nat.
+
+Definition eq_term t1 t2 : bool :=
+  match t1, t2 with 
+  | Pts n1, Pts n2 => n1 == n2
+  | Var v1, Var v2 => v1 == v2
+  | _, _ => false
+  end.
+Lemma eq_termP : Equality.axiom eq_term.
+Proof. 
+case=>n; case=>m /=; try by [constructor];
+by case: eqP=>[->|N]; constructor=>//; case=>/N.
+Qed.
+
+HB.instance Definition _ := hasDecEq.Build term eq_termP.
+
+(* interpretation for terms *) 
+Definition interp' i (t : term) : seq A := 
+ match t with
+    Pts n => if onth (keyx i) n is Some k then [:: k] else [::]
+  | Var n => if onth (varx i) n is Some f then f else [::]
+  end.
+
+(* interpretation for term sequences *)
+Definition interp (i : ctx A) (ts : seq term) : seq A := 
+  foldr (fun t s => interp' i t ++ s) [::] ts.
+
+Lemma interp_cat k ts1 ts2 :
+        interp k (ts1 ++ ts2) = interp k ts1 ++ interp k ts2.
+Proof. by elim: ts1=>[|t ts1 IH] //=; rewrite -catA IH. Qed.
+
+(* interpretation is invariant under context weakening *)
+(* under assumption that the interpreted term is well-formed *)
+Definition wf i t :=
+  match t with
+  | Pts n => n < size (keyx i)
+  | Var n => n < size (varx i)
+  end.
+
+Lemma sc_wf i j ts : 
+        sub_ctx i j -> 
+        all (wf i) ts -> all (wf j) ts.
+Proof.
+case=>/Prefix_size H1 /Prefix_size H2; elim: ts=>[|t ts IH] //=.
+case/andP=>H /IH ->; rewrite andbT.
+by case: t H=>n H; apply: leq_trans H _.
+Qed.
+
+Lemma sc_interp i j ts :
+        sub_ctx i j -> 
+        all (wf i) ts -> 
+        interp i ts = interp j ts.
+Proof.
+case=>H1 H2; elim: ts=>[|t ts IH] //= /andP [H] /IH ->.
+by case: t H=>n /= /Prefix_onth <-.
+Qed.
+
+Definition key n t := if t is Pts m then n == m else false.
+Definition var n t := if t is Var m then n == m else false.
+Definition kfree n t := rfilter (key n) t.
+Definition vfree n t := rfilter (var n) t.
+
+Lemma kfree_sub ts n : {subset kfree n ts <= ts}.  
+Proof.
+elim: ts=>[|x ts IH] // z; rewrite /kfree/= inE.
+case: ifP=>[_ ->|_]; first by rewrite orbT. 
+by rewrite inE; case: (z =P x)=>//= _ /IH.
+Qed.
+
+Lemma vfree_sub ts n : {subset vfree n ts <= ts}.  
+Proof.
+elim: ts=>[|x ts IH] // z; rewrite /vfree/= inE.
+case: ifP=>[_ ->|_]; first by rewrite orbT. 
+by rewrite inE; case: (z =P x)=>//= _ /IH.
+Qed.
+
+Lemma wf_kfree i n ts : 
+        all (wf i) ts -> 
+        all (wf i) (kfree n ts).
+Proof. 
+rewrite /kfree; elim: ts=>//= -[]t ts IH /=; last first.
+- by case/andP=>-> /IH.
+by case: (n =P t)=>[_ /andP []|/= _ /andP [->] /IH].
+Qed.
+
+Lemma wf_vfree i n ts : 
+        all (wf i) ts -> 
+        all (wf i) (vfree n ts).
+Proof. 
+rewrite /vfree; elim: ts=>//= -[]t ts IH /=. 
+- by case/andP=>-> /IH.
+by case: (n =P t)=>[_ /andP []|/= _ /andP [->] /IH].
+Qed.
+
+Lemma keyN i n ts : 
+        ~~ has (key n) ts -> 
+        perm_eq (interp i (kfree n ts)) (interp i ts).
+Proof. 
+elim: ts=>[|t ts IH] //=; rewrite negb_or; case/andP=>H1.
+move/IH=>E; rewrite /kfree /= (negbTE H1) /=.
+by rewrite perm_cat2l E.
+Qed.
+
+Lemma varN i n ts : 
+        ~~ has (var n) ts -> 
+        perm_eq (interp i (vfree n ts)) (interp i ts).
+Proof.
+elim: ts=>[|t ts IH] //=; rewrite negb_or; case/andP=>H1.
+move/IH=>E; rewrite /vfree /= (negbTE H1) /=.
+by rewrite perm_cat2l E.
+Qed.
+
+Lemma keyP i n k ts :
+        has (key n) ts -> 
+        onth (keyx i) n = Some k ->
+        perm_eq (interp i ts) (k :: interp i (kfree n ts)).
+Proof.
+rewrite /kfree; elim: ts=>[|[]t ts IH] //=.
+- case: (n =P t)=>[-> _ ->//|/= _ H /(IH H) {}IH]. 
+  case: (onth _ t)=>[a|] //; rewrite -(cat1s k).  
+  apply: perm_trans (perm_cat _ IH) _=>//.
+  by rewrite -(cat1s k) !catA perm_cat // perm_catC.
+move=>H /(IH H) {}IH.
+case: (onth _ t)=>[a|] //=; rewrite -(cat1s k).
+apply: perm_trans (perm_cat _ IH) _=>//.
+by rewrite -(cat1s k) !catA perm_cat // perm_catC.
+Qed.
+  
+Lemma varP i n u ts :
+        has (var n) ts -> 
+        onth (varx i) n = Some u ->
+        perm_eq (interp i ts) (u ++ interp i (vfree n ts)).
+Proof.
+rewrite /vfree; elim: ts=>[|[]t ts IH] //=.
+- move=>H /(IH H) {}IH.
+  case: (onth _ t)=>[a|] //=; rewrite -(cat1s a).
+  apply: perm_trans (perm_cat _ IH) _=>//. 
+  by rewrite -(cat1s a (interp _ _)) !catA perm_cat // perm_catC.
+case: (n =P t)=>[-> _ ->//|/= _ H /(IH H) {}IH]. 
+case: (onth _ t)=>[a|] //=. 
+apply: perm_trans (perm_cat _ IH) _=>//. 
+by rewrite !catA perm_cat // perm_catC.
+Qed.
+
+End UniqReflection.
+
+(* deciding if ts1 represents a subterm of ts2 *)
+
+Section Subterm.
+Variable A : eqType. 
+Implicit Types (i : ctx A) (ts : seq term).
+
+Fixpoint subterm ts1 ts2 :=
+  match ts1 with
+  | Pts n :: tsx1 =>
+      if has (key n) ts2 then subterm tsx1 (kfree n ts2) else false
+ | Var n :: tsx1 =>
+      if has (var n) ts2 then subterm tsx1 (vfree n ts2) else false
+  | [::] => true
+  end.
+
+(* the procedure is sound for deciding *)
+(* subset and uniqueness properties *)
+
+Lemma subterm_sound_sub i ts1 ts2 :
+        all (wf i) ts1 -> 
+        all (wf i) ts2 -> 
+        subterm ts1 ts2 ->
+        {subset interp i ts1 <= interp i ts2}.
+Proof.
+elim: ts1 ts2=>[|t ts1 IH] ts2 //= A1 A2.
+case/andP: A1; case: t=>t /= /size_onth [k] X A1; rewrite X;
+case: ifP=>Y // /(IH _ A1) S z.
+- rewrite inE; case/orP=>[/eqP ->|].
+  - by rewrite (perm_mem (keyP Y X)) inE eqxx.
+  move/(S (wf_kfree _ A2)).
+  by rewrite (perm_mem (keyP Y X)) inE orbC=>->.
+rewrite mem_cat (perm_mem (varP Y X)) mem_cat.
+case/orP=>[->//|] /(S (wf_vfree _ A2)) ->. 
+by rewrite orbC.
+Qed.
+
+Lemma subterm_sound_uniq i ts1 ts2 :
+        all (wf i) ts1 -> 
+        all (wf i) ts2 -> 
+        subterm ts1 ts2 ->
+        uniq (interp i ts2) ->
+        uniq (interp i ts1).
+Proof. 
+elim: ts1 ts2=>[|[]t ts1 IH] ts2 //= /andP [] /size_onth [k] /[dup] X -> 
+A1 A2; case: ifP=>// Y S.
+- move: (IH _ A1 (wf_kfree _ A2) S)=>{}IH.
+  rewrite (perm_uniq (keyP Y X)) /=. 
+  case/andP=>K /IH ->; rewrite andbT (contra _ K) //.
+  by apply: (subterm_sound_sub A1 (wf_kfree _ A2) S).
+move: (IH _ A1 (wf_vfree _ A2) S)=>{}IH.
+rewrite (perm_uniq (varP Y X)) /= !cat_uniq.  
+case/and3P=>-> /= H /IH ->; rewrite andbT (contra _ H) //.
+case/hasP=>x /(subterm_sound_sub A1 (wf_vfree _ A2) S) V K.
+by apply/hasP; exists x.
+Qed.
+
+End Subterm.
+
+Module Syntactify.
+Section Syntactify.
+Variables (A : eqType).
+Implicit Types (i : ctx A) (ts : seq term).
+
+(* a tagging structure to control the flow of computation *)
+Structure tagged_map := Tag {untag : seq A}.
+
+Local Coercion untag : tagged_map >-> seq.
+
+(* in reversed order; first test for unions, then cons, rcons, empty, and vars *)
+Definition var_tag := Tag.
+Definition empty_tag := var_tag. 
+Definition rcons_tag := empty_tag. 
+Definition cons_tag := rcons_tag. 
+Canonical Structure union_tag hc := cons_tag hc.
+
+(* Main structure                                    *)
+(* - i : input context                               *)
+(* - j : output context                              *)
+(* - ts : syntactification of sequence using context j *)
+
+Definition axiom i j ts (pivot : tagged_map) :=
+  [/\ interp j ts = untag pivot, sub_ctx i j & all (wf j) ts].
+Structure form i j ts := Form {pivot : tagged_map; _ : axiom i j ts pivot}.
+
+Local Coercion pivot : form >-> tagged_map.
+
+Lemma union_pf i j k ts1 ts2 (f1 : form i j ts1) (f2 : form j k ts2) :
+        axiom i k (ts1 ++ ts2) (union_tag (untag f1 ++ untag f2)).
+Proof.
+case: f1 f2=>f1 [E1 S1 W1][f2][E2 S2 W2]; split=>/=.
+- by rewrite interp_cat -(sc_interp S2 W1) E1 E2.
+- by apply: sc_trans S1 S2.
+by rewrite all_cat (sc_wf S2 W1) W2.
+Qed.
+
+Canonical union_form i j k ts1 ts2 f1 f2 :=
+  Form (@union_pf i j k ts1 ts2 f1 f2).
+
+(* check for cons *) 
+Lemma cons_pf i keys2 k j ts (f1 : xfind (keyx i) keys2 k) 
+          (f2 : form (Context keys2 (varx i)) j ts) :
+        axiom i j (Pts k :: ts) (cons_tag (xuntag f1 :: untag f2)).
+Proof.
+case: f1 f2=>f1 [E1 H1][f2][E2 H2 W2]; split=>/=. 
+- by rewrite -(Prefix_onth (onth_size E1) (proj1 H2)) E1 /= E2.
+- by apply: sc_trans H2. 
+by rewrite W2 andbT (leq_trans (onth_size E1)) // (Prefix_size (proj1 H2)).
+Qed.
+
+Canonical cons_form i keys2 k j ts f1 f2 :=
+  Form (@cons_pf i keys2 k j ts f1 f2).
+
+(* check for rcons *) 
+Lemma rcons_pf i j ts keys2 k (f1 : form i j ts) 
+           (f2 : xfind (keyx j) keys2 k) :
+        axiom i (Context keys2 (varx j))
+          (rcons ts (Pts k)) (rcons_tag (rcons (untag f1) (xuntag f2))).
+Proof.
+case: f1 f2=>f1 [E1 H1 W1][f2][E2 H2].
+have H3 : sub_ctx j (Context keys2 (varx j)) by [].
+split=>/=.
+- by rewrite -cats1 interp_cat /= E2 -(sc_interp H3) // cats1 E1.
+- by apply: (sc_trans H1 H3).
+by rewrite all_rcons /= (onth_size E2) (sc_wf H3 W1).
+Qed.
+
+Canonical rcons_form i j ts keys2 k f1 f2 := 
+  Form (@rcons_pf i j ts keys2 k f1 f2).
+
+(* check if reached empty *)
+
+Lemma empty_pf i : axiom i i [::] (empty_tag [::]).
+Proof. by split. Qed.
+
+Canonical empty_form i := Form (@empty_pf i).
+
+(* check for var (default case) *)
+Lemma var_pf i vars2 n (f : xfind (varx i) vars2 n) :
+        axiom i (Context (keyx i) vars2)
+              [:: Var n] (var_tag (xuntag f)).
+Proof. 
+case: f=>f [E H]; split=>//=; first by rewrite E cats0.
+by rewrite (onth_size E).
+Qed. 
+
+Canonical var_form i vars2 n f := Form (@var_pf i vars2 n f).
+
+End Syntactify.
+
+Module Exports.
+Coercion untag : tagged_map >-> seq.
+Coercion pivot : form >-> tagged_map.
+Canonical union_tag.
+Canonical union_form.
+Canonical cons_form.
+Canonical rcons_form. 
+Canonical empty_form. 
+Canonical var_form.
+
+End Exports.
+End Syntactify.
+
+Export Syntactify.Exports.
+
+(*********************************************************************)
+(* Overloaded lemma for concluding uniq facts out of uniq hypothesis *)
+(*********************************************************************)
+
+Module UniqX.
+Section UniqX.
+Variable A : eqType.
+Implicit Types (j : ctx A) (ts : seq term).
+Notation form := Syntactify.form.
+Notation untag := Syntactify.untag.
+
+Structure packed_map (m : seq A) := Pack {unpack : seq A}.
+Canonical equate (m : seq A) := Pack m m.
+
+Definition raxiom j ts1 m (b : bool) (pivot : packed_map m) :=
+  all (wf j) ts1 -> uniq (interp j ts1) -> b -> uniq (unpack pivot).
+
+Structure rform j ts1 m b :=
+  RForm {pivot :> packed_map m; _ : raxiom j ts1 b pivot}.
+
+(* start instance: note how subterm ts2 ts1 is unified with *)
+(* the boolean component of rform *)
+
+Lemma start_pf j k ts1 ts2 (f2 : form j k ts2) :
+        @raxiom j ts1 (untag f2) (subterm ts2 ts1) (equate f2).
+Proof.
+case: f2=>f2 [E S A2] A1; rewrite (sc_interp S A1)=>V.
+move/(subterm_sound_uniq A2 (sc_wf S A1))=>H /=.
+by rewrite -E (H V).
+Qed.
+
+Canonical start j k ts1 ts2 f2 := RForm (@start_pf j k ts1 ts2 f2).
+
+End UniqX.
+
+Module Exports.
+Canonical equate.
+Canonical start.
+
+Section Exports.
+Variable A : eqType.
+Implicit Types (j : ctx A) (ts : seq term).
+Notation form := Syntactify.form.
+Notation untag := Syntactify.untag.
+
+(* main lemma *)
+(* boolean component of rform is set to true *)
+(* so that the lemma succeeds only if the subterm checks suceeds *)
+Lemma uniqO m j ts1 (f1 : form (empx A) j ts1) (g : rform j ts1 m true) :
+        uniq (untag f1) -> uniq (unpack (pivot g)).
+Proof. 
+case: g f1; case=>pivot H [f1][<- Sc X] /=.
+by move/H; apply.
+Qed.
+
+End Exports.
+
+Arguments uniqO {A m j ts1 f1 g}.
+
+End Exports.
+End UniqX.
+
+Export UniqX.Exports.
+
+(***********************************************************************)
+(* Overloaded lemma for concluding _ != _ facts out of uniq hypothesis *)
+(***********************************************************************)
+
+Module NeqX.
+Section NeqX.
+Variable A : eqType.
+Implicit Types (j : ctx A) (ts : seq term).
+Notation form := Syntactify.form.
+Notation untag := Syntactify.untag.
+
+Structure packed_elem (x : A) := Pack {unpack : A}.
+Canonical equate m := Pack m m.
+
+Definition raxiom j ts1 (n : nat) m b (pivot : packed_elem m) :=
+  all (wf j) ts1 -> uniq (interp j ts1) -> b -> 
+    interp j [:: Pts n] != [:: unpack pivot].
+
+Structure rform j ts1 (n : nat) m b :=
+  RForm {pivot :> packed_elem m; _ : raxiom j ts1 n b pivot}.
+
+Lemma start_pf j keys2 ts1 n m (f2 : xfind (keyx j) keys2 m) :
+        @raxiom j ts1 n (xuntag f2) 
+           (subterm [:: Pts n; Pts m] ts1) 
+           (equate (xuntag f2)).
+Proof.
+case: f2; case=>f2 [O P] Aw U S.
+have [Pn Pm] : Pts n \in ts1 /\ Pts m \in ts1.
+- move: S=>/=; case: ifP=>//; case: ifP=>//.
+  case/hasP=>/= -[] xm /kfree_sub Pm //= /eqP ->. 
+  by case/hasP=>/= -[] xn //= Pn /eqP ->.
+have Sn : wf j (Pts n) by move/allP: Pn; apply. 
+have Sm : wf j (Pts m) by move/allP: Pm; apply.
+have Ax: all (wf j) [:: Pts n; Pts m] by apply/and3P.
+move: (subterm_sound_uniq Ax Aw S U)=>/=.
+rewrite (Prefix_onth Sm P) O /= cat_uniq cats0.
+case: (onth _ _)=>//= a; rewrite orbF andbT inE.
+by apply: contra=>/eqP [->].
+Qed.
+
+Canonical start j keys2 ts1 n m f2 := RForm (@start_pf j keys2 ts1 n m f2).
+
+End NeqX.
+
+Module Exports.
+Canonical equate.
+Canonical start.
+
+Section Exports.
+Variable A : eqType.
+Implicit Types (j : ctx A) (ts : seq term).
+Notation form := Syntactify.form.
+Notation untag := Syntactify.untag.
+
+(* main lemma *)
+Lemma neqO n m i keys2 ts1 (f : form (empx A) i ts1) 
+          (x : xfind (keyx i) keys2 n) 
+          (y : rform (Context keys2 (varx i)) ts1 n m true) :
+        uniq (untag f) -> xuntag x != unpack (pivot y).
+Proof.
+case: f=>f [Ef S Aw]; case: x=>x [O P]; case: y=>y H.
+rewrite /raxiom/= -Ef O cats0 in H *.
+have {}S : sub_ctx i (Context keys2 (varx i)) by [].
+rewrite -(sc_interp S) // (sc_wf S) // in H.
+by move/(H erefl)=>/(_ erefl); apply: contra=>/eqP ->.
+Qed.
+
+Lemma test (x y z : A) : 
+        uniq [:: x; y; z] ->
+        (z != y)*(z != x) * (x != y).
+Proof. by move=>U; rewrite !(neqO _ _ U). Abort.
+
+End Exports.
+
+Arguments neqO {A n m i keys2 ts1 f x y}.
+
+End Exports.
+End NeqX.
+
+Export NeqX.Exports.
+
+(***************************************************************************)
+(* Overloaded lemma for concluding _ \notin _ facts out of uniq hypothesis *)
+(***************************************************************************)
+
+Module NotinX.
+Section NotinX.
+Variable A : eqType.
+Implicit Types (j : ctx A) (ts : seq term).
+Notation form := Syntactify.form.
+Notation untag := Syntactify.untag.
+
+Structure packed_map (x : seq A) := Pack {unpack : seq A}.
+Canonical equate m := Pack m m.
+
+Definition raxiom j ts1 (n : nat) m b (pivot : packed_map m) :=
+  all (wf j) ts1 -> uniq (interp j ts1) -> b -> 
+    uniq (interp j [:: Pts n] ++ unpack pivot).
+
+Structure rform j ts1 (n : nat) m b :=
+  RForm {pivot :> packed_map m; _ : raxiom j ts1 n b pivot}.
+
+Lemma start_pf j k ts1 ts2 n (f2 : form j k ts2) :
+        @raxiom j ts1 n (untag f2) 
+           (subterm [:: Pts n & ts2] ts1) 
+           (equate f2).
+Proof.
+case: f2=>f2 [E S A2] A1 U X /=.
+have Pn : Pts n \in ts1.
+- by move: X=>/=; case: ifP=>// /hasP [][] // xn /[swap] /eqP=>->. 
+have Sn : wf j (Pts n) by move/allP: Pn; apply.
+rewrite (sc_interp S A1) in U; move/(sc_wf S): A1=>A1.
+have Ax : all (wf k) (Pts n :: ts2). 
+- by apply/andP; split=>//; move/allP: Pn; apply.
+move: (subterm_sound_uniq Ax A1 X U). 
+by rewrite (Prefix_onth Sn (proj1 S)) cats0 -E.
+Qed.
+
+Canonical start j k ts1 ts2 n f2 := RForm (@start_pf j k ts1 ts2 n f2).
+
+End NotinX.
+
+Module Exports.
+Canonical equate.
+Canonical start.
+
+Section Exports.
+Variable A : eqType.
+Implicit Types (j : ctx A) (ts : seq term).
+Notation form := Syntactify.form.
+Notation untag := Syntactify.untag.
+
+(* main lemma *)
+Lemma notinO n m i keys2 ts1 (f : form (empx A) i ts1) 
+          (x : xfind (keyx i) keys2 n) 
+          (y : rform (Context keys2 (varx i)) ts1 n m true) :
+        uniq (untag f) -> xuntag x \notin unpack (pivot y).
+Proof.
+case: f=>f [Ef S Aw]; case: x=>x [O P]; case: y=>y H.
+rewrite /raxiom/= -Ef O cats0 in H *.
+have {}S : sub_ctx i (Context keys2 (varx i)) by [].
+rewrite -(sc_interp S) // (sc_wf S) // in H.
+by move/(H erefl)=>/(_ erefl) /andP [].
+Qed.
+
+Lemma test (x y z : A) : 
+        uniq [:: x; y; z] ->
+        (x \notin [:: z; y]) * (y \notin [:: x; z]).
+Proof. by move=>U; rewrite !(notinO _ _ U). Abort.
+
+End Exports.
+
+Arguments notinO {A n m i keys2 ts1 f x y}.
+
+End Exports.
+End NotinX.
+
+Export NotinX.Exports.
+
+(* packaging the three automated lemmas into one *)
+(* stating them in the form X = false instead of ~~ X *)
+(* so that rewrites apply to positive terms as well *)
+Lemma uniqX' (A : eqType) i ts1 (f1 : Syntactify.form (empx A) i ts1) :
+        uniq f1 -> 
+          (forall m (g : UniqX.rform i ts1 m true), 
+             uniq (UniqX.unpack (UniqX.pivot g))) * 
+          (forall n keys2 (x : xfind (keyx i) keys2 n),
+             ((forall m (y : NeqX.rform (Context keys2 (varx i)) ts1 n m true),
+               xuntag x == NeqX.unpack (NeqX.pivot y) = false) * 
+             (forall m (y : NotinX.rform (Context keys2 (varx i)) ts1 n m true),
+               xuntag x \in NotinX.unpack (NotinX.pivot y) = false))).
+Proof. 
+by move=>U; split; [|split]=>*; first by [apply: uniqO U];
+apply/negbTE; [apply: neqO U|apply: notinO U].
+Qed.
+
+(* adding common goal transformations *)
+(* that appear when reasoning about uniq *)
+Definition uniqX {A i ts1 f1} U := 
+  (mem_rcons, mem_cat, inE, negb_or, rcons_uniq, cat_uniq, andbT, orbF, 
+   @uniqX' A i ts1 f1 U).
+

--- a/core/finmap.v
+++ b/core/finmap.v
@@ -981,7 +981,7 @@ Definition mapf' (m : seq (K * U)) : seq (K * V) :=
 Lemma map_key_mapf (m : seq (K * U)) : map key (mapf' m) = map key m.
 Proof. by elim: m=>[|[k v] m IH] //=; rewrite IH. Qed.
 
-Lemma sorted_map (m : seq (K * U)) :
+Lemma sorted_map_key (m : seq (K * U)) :
         sorted ord (map key m) -> sorted ord (map key (mapf' m)).
 Proof.
 elim: m=>[|[k v] m IH] //= H.
@@ -991,7 +991,7 @@ by apply/(order_path_min _ H);apply/trans.
 Qed.
 
 Definition mapf (m : finMap K U) : finMap K V :=
-  let: FinMap _ pf := m in FinMap (sorted_map pf).
+  let: FinMap _ pf := m in FinMap (sorted_map_key pf).
 
 Lemma supp_mapf (s : finMap K U) :
         supp (mapf s) = supp s.
@@ -1134,7 +1134,7 @@ Fixpoint zip' (s1 s2 : seq (K * V)) :=
   | _, _ => None
   end.
 
-Definition zip_unit' (s : seq (K * V)) := @mapf' K _ _ unit_f s.
+Definition zip_unit' (s : seq (K * V)) := @mapf' K V V unit_f s.
 
 Lemma zipC' s1 s2 : zip' s1 s2 = zip' s2 s1.
 Proof.

--- a/core/ordtype.v
+++ b/core/ordtype.v
@@ -43,8 +43,8 @@ HB.mixin Record isOrdered T of Equality T := {
 (* In this file in particular, the canonicals for each instance *)
 (* must be declared by hand as HB.instance does that *)
 (* only if Ordered is declared by HB.structure *)
-
-(* #[log(raw)] 
+(*
+#[log(raw)]
 #[short(type="ordType")]
 HB.structure Definition Ordered := 
   {T of Equality T & isOrdered T}.
@@ -198,6 +198,7 @@ Global Arguments ordtype_subproof {_}.
 
 Notation Ordered X1 := (Ordered.axioms_ X1). 
 (* end of generated and changed code *)
+
 
 (* Repacking *)
 
@@ -470,8 +471,7 @@ case: (x =P y)=>[-> H|/eqP/connex //].
 by apply: IH; apply: contra H=>/eqP ->.
 Qed.
 
-HB.instance Definition seq_ord_mix := 
-  isOrdered.Build (seq T) seq_is_ordtype.
+HB.instance Definition seq_ord_mix := isOrdered.Build (seq T) seq_is_ordtype.
 (* manual canonical declaration, as HB fails to declare it *)
 Canonical seq_ordType : ordType :=
   Ordered.Pack (sort:=seq T) (Ordered.Class seq_ord_mix).

--- a/core/prelude.v
+++ b/core/prelude.v
@@ -541,6 +541,12 @@ Proof. by case: a=>//=->. Qed.
 Lemma iffE (b1 b2 : bool) : b1 = b2 <-> (b1 <-> b2).
 Proof. by split=>[->|] //; move/iffPb/eqP. Qed.
 
+Lemma orPl (a b : bool) : reflect (a \/ ~~ a /\ b) (a || b).
+Proof. by case: a; case: b=>/=; constructor; auto; case=>//; case. Qed.
+
+Lemma orPr (a b : bool) : reflect (~~ b /\ a \/ b) (a || b).
+Proof. by case: a; case: b=>/=; constructor; auto; case=>//; case. Qed.
+
 (* subsets *)
 
 Lemma subsetC T (p q : mem_pred T) :

--- a/meta.yml
+++ b/meta.yml
@@ -48,8 +48,8 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '2.3.0-coq-8.20'
   repo: 'mathcomp/mathcomp'
-- version: 'latest-coq-dev'
-  repo: 'mathcomp/mathcomp'
+- version: 'oq-dev'
+  repo: 'mathcomp/mathcomp-dev'
 
 dependencies:
 - opam:

--- a/meta.yml
+++ b/meta.yml
@@ -48,7 +48,7 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '2.3.0-coq-8.20'
   repo: 'mathcomp/mathcomp'
-- version: 'oq-dev'
+- version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
 
 dependencies:

--- a/meta.yml
+++ b/meta.yml
@@ -56,10 +56,10 @@ dependencies:
     name: coq-mathcomp-ssreflect
     version: '{ (>= "2.2.0" & < "2.4~") | (= "dev") }'
   description: |-
-    [MathComp ssreflect 2.2](https://math-comp.github.io)
+    [MathComp ssreflect 2.2 or later](https://math-comp.github.io)
 - opam:
     name: coq-hierarchy-builder
-    version: '{>= "1.7.0"}'
+    version: '{>= "1.7.0" & < "1.8~"} | (= "dev") }'
   description: |-
     [Hierarchy Builder 1.7.0 or later](https://github.com/math-comp/hierarchy-builder)
 - opam:

--- a/meta.yml
+++ b/meta.yml
@@ -59,7 +59,7 @@ dependencies:
     [MathComp ssreflect 2.2 or later](https://math-comp.github.io)
 - opam:
     name: coq-hierarchy-builder
-    version: '{>= "1.7.0" & < "1.9~"} | (= "dev") }'
+    version: '{ (>= "1.7.0" & < "1.9~") | (= "dev") }'
   description: |-
     [Hierarchy Builder 1.7.0 or later](https://github.com/math-comp/hierarchy-builder)
 - opam:

--- a/meta.yml
+++ b/meta.yml
@@ -48,8 +48,8 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '2.3.0-coq-8.20'
   repo: 'mathcomp/mathcomp'
-- version: 'coq-dev'
-  repo: 'mathcomp/mathcomp-dev'
+- version: 'latest-coq-dev'
+  repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:

--- a/meta.yml
+++ b/meta.yml
@@ -59,7 +59,7 @@ dependencies:
     [MathComp ssreflect 2.2 or later](https://math-comp.github.io)
 - opam:
     name: coq-hierarchy-builder
-    version: '{>= "1.7.0" & < "1.8~"} | (= "dev") }'
+    version: '{>= "1.7.0" & < "1.9~"} | (= "dev") }'
   description: |-
     [Hierarchy Builder 1.7.0 or later](https://github.com/math-comp/hierarchy-builder)
 - opam:

--- a/meta.yml
+++ b/meta.yml
@@ -48,8 +48,8 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '2.3.0-coq-8.20'
   repo: 'mathcomp/mathcomp'
-- version: 'latest-coq-dev'
-  repo: 'mathcomp/mathcomp'
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
 
 dependencies:
 - opam:

--- a/pcm/automap.v
+++ b/pcm/automap.v
@@ -43,7 +43,7 @@ From pcm Require Import pcm unionmap natmap.
 (* The context of keys is thus seq K. The context of vars is seq U.      *)
 
 Section ReflectionContexts.
-Variables (K : ordType) (C : pred K) (T : Type) (U : union_map C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 
 Structure ctx := Context {keyx : seq K; varx : seq U}.
 
@@ -74,8 +74,8 @@ End ReflectionContexts.
 (* now for reflection *)
 
 Section Reflection.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
-Implicit Type i : @ctx K _ _ U.
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
+Implicit Type i : ctx (K:=K) U.
 
 Inductive term := Pts of nat & T | Var of nat.
 
@@ -200,7 +200,7 @@ End Reflection.
 (* subterm is purely functional version of validX *)
 
 Section Subterm.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (i : ctx U) (ts : seq (term T)).
 
 Fixpoint subterm ts1 ts2 :=
@@ -232,7 +232,7 @@ End Subterm.
 (* subtract is purely functional version of domeqX *)
 
 Section Subtract.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (i : ctx U) (ts : seq (term T)).
 
 (* We need a subterm lemma that returns the uncancelled stuff from *)
@@ -273,7 +273,7 @@ End Subtract.
 (* invalid is a purely functional test of invalidX *)
 
 Section Invalid.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (i : ctx U) (t : term T) (ts : seq (term T)).
 
 Definition undefx i t :=
@@ -315,7 +315,7 @@ End Invalid.
 
 Module Syntactify.
 Section Syntactify.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (i : ctx U) (ts : seq (term T)).
 
 (* a tagging structure to control the flow of computation *)
@@ -404,7 +404,7 @@ Export Syntactify.Exports.
 
 Module ValidX.
 Section ValidX.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (j : ctx U) (ts : seq (term T)).
 Notation form := Syntactify.form.
 Notation untag := Syntactify.untag.
@@ -471,7 +471,7 @@ Canonical equate.
 Canonical start.
 
 Section Exports.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (j : ctx U) (ts : seq (term T)).
 Notation form := Syntactify.form.
 Notation untag := Syntactify.untag.
@@ -509,7 +509,7 @@ Export ValidX.Exports.
 
 Module DomeqX.
 Section DomeqX.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (j : ctx U) (ts : seq (term T)).
 Notation form := Syntactify.form.
 Notation untag := Syntactify.untag.
@@ -548,7 +548,7 @@ Canonical equate.
 Canonical start.
 
 Section Exports.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (j : ctx U) (ts : seq (term T)).
 Notation form := Syntactify.form.
 Notation untag := Syntactify.untag.
@@ -583,7 +583,7 @@ Export DomeqX.Exports.
 
 Module InvalidX.
 Section InvalidX.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (i : ctx U) (ts : seq (term T)).
 Notation form := Syntactify.form.
 Notation untag := Syntactify.untag.
@@ -614,7 +614,7 @@ Canonical equate.
 Canonical start.
 
 Section Exports.
-Variables (K : ordType) (C : pred K) (T : Type) (U : @union_map K C T).
+Variables (K : ordType) (C : pred K) (T : Type) (U : union_map K C T).
 Implicit Types (i : ctx U) (ts : seq (term T)).
 Notation form := Syntactify.form.
 Notation untag := Syntactify.untag.

--- a/pcm/heap.v
+++ b/pcm/heap.v
@@ -324,8 +324,8 @@ Lemma updi_inv x xs1 xs2 :
         valid (updi x xs1) -> updi x xs1 = updi x xs2 -> xs1 = xs2.
 Proof.
 elim: xs1 x xs2 =>[|v1 xs1 IH] x /=; case=>[|v2 xs2] //= D.
-- by case/esym/umap0E=>/unitbP; rewrite um_unitbPt. 
-- by case/umap0E=>/unitbP; rewrite um_unitbPt.
+- by case/esym/join0I=>/unitbP; rewrite um_unitbPt. 
+- by case/join0I=>/unitbP; rewrite um_unitbPt.
 by case/(hcancelV D)=><- {}D /(IH _ _ D) <-.
 Qed.
 

--- a/pcm/morphism.v
+++ b/pcm/morphism.v
@@ -13,7 +13,7 @@ limitations under the License.
 
 From HB Require Import structures.
 From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype choice fintype finfun.
+From mathcomp Require Import ssrnat eqtype fintype finfun.
 From pcm Require Import options pred axioms prelude.
 From pcm Require Import pcm.
 
@@ -2369,11 +2369,25 @@ case/fpVI=>/= W1 H1 /fpVI [/= W2 H2].
 by rewrite -(pval_psub S _ W1 H1) -(pval_psub S _ W2 H2) E.
 Qed.
 
+(* unitb *)
+
+Lemma unitb_psub (x : V) : unitb (psub S x) = unitb x.
+Proof.
+apply/unitbP/unitbP=>[E|->]; last by rewrite pfunit.
+by apply: psub_inj; [rewrite E|rewrite pfunit].
+Qed.
+
+Lemma unitb_pval (x : U) : unitb (pval S x) = unitb x.
+Proof.
+apply/unitbP/unitbP=>[E|->]; last by rewrite pfunit.
+by apply: pval_inj; rewrite pfunit.
+Qed.
+
 End DerivedLemmas.
 
 Prenex Implicits valid_sepE valid_pvalE valid_pvalEP valid_pvalS valid_psubS 
 valid_sepUnE valid_pvalUnE valid_pvalUnS valid_sep3E valid_psubUnX valid_psubXUn 
-psubUnX psubXUn pvalXUn pvalUnX pval_inj psub_inj.
+psubUnX psubXUn pvalXUn pvalUnX pval_inj psub_inj unitb_psub unitb_pval.
 
 
 (* properties of V propagate to U *)
@@ -2796,6 +2810,21 @@ move=>X; apply: valx_inj.
 rewrite /undef/= xsep_undefE valxE /psub/= subxE /=.
 by case: decP=>//; rewrite (negbTE X) andbF.  
 Qed.
+
+(***************************)
+(* xsep preserves conicity *)
+(***************************)
+
+Lemma xsep_is_conic (V : tpcmc) (D : seprel V) : 
+        pcmc_axiom (xsep D).
+Proof.
+move=>x y; case: (normalP (x \+ y))=>[//|W].
+rewrite /unitb /= xsep_unitbE pfjoinT //=.
+by move/join00.  
+Qed.
+
+HB.instance Definition _ (V : tpcmc) (D : seprel V) := 
+  isPCMC.Build (xsep D) (@xsep_is_conic V D).
 
 (*****************************************)
 (* Normalize = mod out trivially by relT *)

--- a/pcm/mutex.v
+++ b/pcm/mutex.v
@@ -80,6 +80,14 @@ Lemma mutex_is_normal : normal_tpcm_axiom (mutex T).
 Proof. by case; [right|rewrite valid_unit; left|move=>t; left]. Qed.
 HB.instance Definition _ : isNormal_TPCM (mutex T) :=
   isNormal_TPCM.Build (mutex T) mutex_is_normal.
+
+(* conicity *)
+Lemma mutex_is_conical : pcmc_axiom (mutex T).
+Proof. by case=>[||x1][||x2]. Qed.
+
+HB.instance Definition _ := 
+  isPCMC.Build (mutex T) mutex_is_conical.
+
 End GeneralizedMutex.
 
 (* if T is eqType, so is mutex T *)

--- a/pcm/natmap.v
+++ b/pcm/natmap.v
@@ -291,7 +291,7 @@ Lemma lastkeyP A (U : natmap A) (h : U) :
                            (last_val h).
 Proof.
 have L (x : U) : valid x -> last_key x \notin dom x -> x = Unit.
-- rewrite /last_key !umEX /UM.valid/UM.dom/UM.empty -{4}[x]tfE. 
+- rewrite /last_key/domx !umEX /UM.valid/UM.dom/UM.empty -{4}[x]tfE. 
   case: (UMC_from x)=>//=; case=>s H H1 _ /seq_last_in. 
   by rewrite eqE UM.umapE /supp fmapE /= {H H1}; elim: s. 
 case: (normalP0 h)=>[->|->|].
@@ -339,7 +339,7 @@ Lemma dom_lastkey h k :
         k \in dom h -> 
         k <= last_key h.
 Proof.
-rewrite /last_key !umEX /UM.dom; case: (UMC_from h)=>//; case=>s H _ /=.
+rewrite /last_key/domx !umEX /UM.dom; case: (UMC_from h)=>//; case=>s H _ /=.
 rewrite /supp/ord /= (leq_eqVlt k) orbC. 
 by apply: sorted_last_key_maxR otrans (sorted_oleq H).
 Qed.
@@ -561,9 +561,9 @@ Proof.
 move=>D; have {}D : last_key h \in dom h by case: lastkeyP D.
 case: (um_eta D)=>v [Ef Eh].
 have N : last_key h \notin dom (free h (last_key h)).
-- by rewrite domF inE eqxx.
+- by rewrite domF eqxx.
 have: last_key (free h (last_key h)) <= last_key h.
-- by apply: lastkey_mono=>x; rewrite domF inE; case: ifP.
+- by apply: lastkey_mono=>x; rewrite domF; case/andP.
 rewrite leq_eqVlt; case/orP=>// /eqP E; rewrite -{1}E in N.
 have : last_key h > 0 by move/dom_cond: D; case: (last_key h).
 by case: lastkeyP N.

--- a/pcm/unionmap.v
+++ b/pcm/unionmap.v
@@ -444,7 +444,7 @@ have [k H3] : exists k, k \in supp fx.
 - case: (supp fx) {E1 E} E2=>[|k s _] //.
   by exists k; rewrite inE eqxx. 
 suff : k \in supp (fcat fx fy) by rewrite E1. 
-by rewrite supp_fcat inE H3.
+by rewrite supp_fcat inE /= H3.
 Qed.
 
 HB.instance Definition _ := isPCMC.Build T union_map_is_conical.


### PR DESCRIPTION
* A new minor release to support Hierarchy Builder 1.8.
* Added automation for reasoning about uniqueness of sequences.
* Added  a type class of conical PCMs.
* Made dom infer the union_map structure, in order to support structure-specific notation for dom.
* Added a type class of total map-like functions in unionmap.v. Previous version had only partial map-like function (omap_fun), but total ones admit better lemmas.
* Generalized several \big lemmas in unionmap.v that were previously unnecessarily restricted (bigD1FE, bigPtUnE, bigPtUn, bigDUE).
* Added a number of smaller lemmas in pred, prelude, seqext, unionmap. 