### PR TITLE
Adapt to math-comp/math-comp#1580

### DIFF
--- a/pcm/minus.v
+++ b/pcm/minus.v
@@ -488,8 +488,8 @@ HB.instance Definition _ := TPCMS.on oint2.
 
 Module RWsep.
 Import intZmod intOrdered ssralg.GRing ssralg.GRing.Theory Num.Theory Num.Def.
-Import order.Order.TTheory order.Order.DefaultProdOrder order.Order.ProdSyntax.
-Import order.Order.DefaultProdLexiOrder order.Order.LexiSyntax.  
+Import Order.TTheory Order.DefaultProdOrder Order.ProdSyntax.
+Import Order.DefaultProdLexiOrder Order.LexiSyntax.
 Local Open Scope order_scope.
 Local Open Scope ring_scope.
 


### PR DESCRIPTION
Since `order.v` in MathComp is 8k lines long, we started splitting it into several files. After this change, we cannot assume that `Order.*` modules are declared in `order.v`.

See math-comp/math-comp#1580 and math-comp/math-comp#1508 for details.